### PR TITLE
add "in Astro" to Routing default question

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -544,7 +544,7 @@ const meta: Meta = {
           if (textarea.placeholder === "Why should I use Astro?") {
             message = textarea.placeholder;
             textarea.placeholder = "How does routing work?";
-          } else if (textarea.placeholder === "How does routing work?") {
+          } else if (textarea.placeholder === "How does routing work in Astro?") {
             message = textarea.placeholder;
             textarea.placeholder = "Ask another question...";
           } else {


### PR DESCRIPTION
Our answers tend to be better when they end in "in Astro?" (where appropriate.)

I think the "... in Astro?" answer is more useful to showcase as a default.

Current answer to: "How Does Routing Work?"

> Routing in Astro works by using file-based routing, where each file in the src/pages/ directory becomes an endpoint on the site based on its file path. Static routes without path parameters take precedence over all other routes, and dynamic routes using named parameters take precedence over rest parameters.

Answer to: "How Does Routing Work in Astro?"

> In Astro, routing works by automatically generating URLs based on the file layout of the project's src/pages/ directory. Dynamic routing is also supported, allowing for pages to be generated from content collections or a CMS. Navigation between pages is done using standard HTML <a> elements.