### PR TITLE
Mobile CSS Adjustments

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -28,16 +28,18 @@ const meta: Meta = {
     <header class="container">
       <Houston glow />
       <div class="intro">
-        <p class="intro-title">
-          <HoustonAI />
-        </p>
-        <p class="intro-subtitle">
-          Hi, I'm Houston! I've read the entire <a
+        <div class="intro-content">
+          <p class="intro-title">
+            <HoustonAI />
+          </p>
+          <p class="intro-subtitle">
+            Hi, I'm Houston! I've read the entire <a
             href="https://docs.astro.build/"
             target="_blank">Astro Docs</a
-          > (a few thousand times). Ask me how to do anything in Astro. I'll do my
-          best to answer!
-        </p>
+            > (a few thousand times). Ask me how to do anything in Astro. I'll do my
+            best to answer!
+          </p>
+        </div>
       </div>
     </header>
     <main class="container">
@@ -148,7 +150,7 @@ const meta: Meta = {
       header {
         position: relative;
         margin: 0.75rem;
-        padding: 1.25rem;
+        padding: 0.75rem;
         display: flex;
         flex-direction: column;
         align-items: center;
@@ -161,10 +163,13 @@ const meta: Meta = {
         user-select: none;
       }
       .intro {
-        max-width: 400px;
+        max-width: 100%;
         color: white;
         transition: opacity 500ms ease-out;
         text-align: left;
+      }
+      .intro .intro-content {
+        max-width: 400px;
       }
       .intro .intro-title {
         margin: 2rem 0 0 0;
@@ -180,7 +185,7 @@ const meta: Meta = {
       .intro .intro-subtitle {
         margin: 0.25rem 0 1rem 0;
         color: rgba(133, 139, 152, 1);
-        text-align: justify;
+        text-align: left;
         font-size: 1.3rem;
         padding: 0 0.5rem;
       }


### PR DESCRIPTION
Hi Astro team,

When I opened the live [Houston tool](https://houston.astro.build/) on mobile I noticed that the text was overflowing off the edge of the screen like so:

![image](https://user-images.githubusercontent.com/20733264/215303492-76e47a29-a039-4a70-9ebc-ea9f4a9fbe03.png)

This PR resolves that issue, with the result looking like this:

![image](https://user-images.githubusercontent.com/20733264/215303566-1b97cc58-53b6-430e-914b-fc3a491755d5.png)

The simplest way to keep your desktop design the same while preventing overflow on mobile was to add an extra `div` and style it accordingly. I tested on desktop and it appears to not have any breaking changes.

While in the code I made 2 more tiny tweaks to the design.

1. Changed the text alignment from `justify` to `left`. Again, this was a mobile issue, but I noticed that the word spacing was a bit wacky. Aligning left still looks ok (in my opinion), and prevents this issue.

![image](https://user-images.githubusercontent.com/20733264/215303659-9ad6d19b-38ae-40a3-8f05-c33351cc36f1.png)
^ An example of `text-align: justify` giving the words excessive spacing.

2. Reduced the padding slightly on the header. This change is barely noticeable on desktop but gives a little more real-estate for the hero text on mobile.

---

I hope you agree that these changes are an improvement! Happy to collaborate and co-operate further on this if needed. :)